### PR TITLE
Use the public interface for require statements

### DIFF
--- a/UdpSocket.ios.js
+++ b/UdpSocket.ios.js
@@ -14,9 +14,11 @@
 
 var inherits = require('inherits')
 var EventEmitter = require('events').EventEmitter
-var React = require('react-native')
-var DeviceEventEmitter = require('RCTDeviceEventEmitter')
-var Sockets = require('NativeModules').UdpSockets
+var {
+  DeviceEventEmitter,
+  NativeModules
+} = require('react-native');
+var Sockets = NativeModules.UdpSockets
 var base64 = require('base64-js')
 var noop = function () {}
 var instances = 0


### PR DESCRIPTION
0.7.1 mandates that all native module require statements use the public interfafe, else the packager will fail.
https://github.com/facebook/react-native/releases/tag/v0.7.0-rc