### PR TITLE
Compile errors for empty generics definitions

### DIFF
--- a/android/src/main/java/com/tradle/react/UdpSenderTask.java
+++ b/android/src/main/java/com/tradle/react/UdpSenderTask.java
@@ -26,7 +26,7 @@ public class UdpSenderTask extends AsyncTask<UdpSenderTask.SenderPacket, Void, V
 
     public UdpSenderTask(DatagramSocket socket, OnDataSentListener listener) {
         this.mSocket = socket;
-        this.mListener = new WeakReference<>(listener);
+        this.mListener = new WeakReference<OnDataSentListener>(listener);
     }
 
     @Override

--- a/android/src/main/java/com/tradle/react/UdpSocketClient.java
+++ b/android/src/main/java/com/tradle/react/UdpSocketClient.java
@@ -44,7 +44,7 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
         this.mReceiverListener = builder.receiverListener;
         this.mExceptionListener = builder.exceptionListener;
         this.mReuseAddress = builder.reuse;
-        this.mPendingSends = new ConcurrentHashMap<>();
+        this.mPendingSends = new ConcurrentHashMap<UdpSenderTask, Callback>();
     }
 
     /**

--- a/android/src/main/java/com/tradle/react/UdpSockets.java
+++ b/android/src/main/java/com/tradle/react/UdpSockets.java
@@ -37,7 +37,7 @@ public final class UdpSockets extends ReactContextBaseJavaModule
     private static final String TAG = "UdpSockets";
     private WifiManager.MulticastLock mMulticastLock;
 
-    private SparseArray<UdpSocketClient> mClients = new SparseArray<>();
+    private SparseArray<UdpSocketClient> mClients = new SparseArray<UdpSocketClient>();
     private boolean mShuttingDown = false;
 
     public UdpSockets(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/tradle/react/UdpSocketsModule.java
+++ b/android/src/main/java/com/tradle/react/UdpSocketsModule.java
@@ -23,7 +23,7 @@ public final class UdpSocketsModule implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
-        List<NativeModule> modules = new ArrayList<>();
+        List<NativeModule> modules = new ArrayList<NativeModule>();
 
         modules.add(new UdpSockets(reactContext));
 


### PR DESCRIPTION
On earlier versions of Java (I believe that's the reason), this will raise some compiler problems.

![screen shot 2015-11-30 at 2 43 41 pm](https://cloud.githubusercontent.com/assets/656630/11482478/054ce09c-9771-11e5-863f-bef1d25fff01.png)

After patch:
![screen shot 2015-11-30 at 2 45 49 pm](https://cloud.githubusercontent.com/assets/656630/11482488/124bcb64-9771-11e5-939f-e4ac18fc495d.png)


Great library btw :+1: 