### PR TITLE
Allow hostnames in addition to IP addresses

### DIFF
--- a/UdpSocket.js
+++ b/UdpSocket.js
@@ -21,6 +21,8 @@ var {
 var Sockets = NativeModules.UdpSockets
 var base64 = require('base64-js')
 var ipRegex = require('ip-regex')
+// RFC 952 hostname format
+var hostnameRegex = /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 var noop = function () {}
 var instances = 0
 var STATE = {
@@ -162,7 +164,7 @@ UdpSocket.prototype.send = function(buffer, offset, length, port, address, callb
   var self = this
 
   if (typeof port !== 'number') throw new Error('invalid port')
-  if (!isValidIP(address, this._ipRegex)) throw new Error('invalid address')
+  if (!isValidIpOrHostname(address, this._ipRegex)) throw new Error('invalid address')
 
   if (offset !== 0) throw new Error('Non-zero offset not supported yet')
 
@@ -269,10 +271,10 @@ UdpSocket.prototype.unref = function() {
   // anything?
 }
 
-function isValidIP (address, ipRegex) {
+function isValidIpOrHostname (address, ipRegex) {
   if (typeof address !== 'string') return false
 
-  return ipRegex.test(address)
+  return ipRegex.test(address) || hostnameRegex.test(address);
 }
 
 function normalizeError (err) {


### PR DESCRIPTION
Via #12, to get hostnames working we just need to tweak the IP validator to also check for valid hostnames by the [RFC952](http://tools.ietf.org/html/rfc952) spec.

Both the [ios](https://github.com/tradle/react-native-udp/blob/master/ios/UdpSocketClient.m#L141) and [android](https://github.com/tradle/react-native-udp/blob/master/android/src/main/java/com/tradle/react/UdpSocketClient.java#L160) sockets allow a host to be a string IP or hostname.

This has been verified to work on both iOS and Android.

Closes #12.