### PR TITLE
Set max buffer size to maximum allowed

### DIFF
--- a/ios/UdpSocketClient.m
+++ b/ios/UdpSocketClient.m
@@ -93,6 +93,9 @@ NSString *const RCTUDPErrorDomain = @"RCTUDPErrorDomain";
   _address = address;
 
   _udpSocket = [[GCDAsyncUdpSocket alloc] initWithDelegate:self delegateQueue:[self methodQueue]];
+  
+  [_udpSocket setMaxReceiveIPv4BufferSize:UINT16_MAX];
+  
   BOOL result;
   if (address) {
     struct sockaddr_in ip;

--- a/ios/UdpSocketClient.m
+++ b/ios/UdpSocketClient.m
@@ -95,6 +95,7 @@ NSString *const RCTUDPErrorDomain = @"RCTUDPErrorDomain";
   _udpSocket = [[GCDAsyncUdpSocket alloc] initWithDelegate:self delegateQueue:[self methodQueue]];
   
   [_udpSocket setMaxReceiveIPv4BufferSize:UINT16_MAX];
+  [_udpSocket setMaxReceiveIPv6BufferSize:UINT16_MAX];
   
   BOOL result;
   if (address) {


### PR DESCRIPTION
I'm evaluating this library for an application that sends ~60kb size UDP messages. Without this setting the messages are cut off at the default message size.

This is probably something you'd want to set with `const socket = dgram.createSocket('udp4', { maxBufferSize: 'UINT16_MAX' })`. I've modified the library to automatically choose the largest allowed size `GCDAsyncUdpSocket` allows (which is 64kb).