### PR TITLE
Don't include examples in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,42 @@
+# Xcode
+!**/*.xcodeproj
+!**/*.pbxproj
+!**/*.xcworkspacedata
+!**/*.xcsettings
+!**/*.xcscheme
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Xcode, Gradle
+build/
+
+# Android
+.idea
+.gradle
+local.properties
+*.iml
+
+# Node
+node_modules
+*.log
+.nvm
+
+# OS X
+.DS_Store
+
 # examples is not required in npm package
 examples/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# examples is not required in npm package
+examples/

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
   "scripts": {
     "start": "exit 1"
   },
-  "files": [
-    "android",
-    "ios",
-    "UdpSocket.js",
-    "UdpSockets.js"
-  ],
   "browser": {
     "dgram": "./UdpSockets.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-udp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "node's dgram API for react-native",
   "main": "UdpSockets.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "scripts": {
     "start": "exit 1"
   },
+  "files": [
+    "android",
+    "ios",
+    "UdpSocket.js",
+    "UdpSockets.js"
+  ],
   "browser": {
     "dgram": "./UdpSockets.js"
   },


### PR DESCRIPTION
The npm package being published are quite big in size (around 70MB). The npm install takes quite a lot of time while installing the package because of this. The problem is the examples folder was also being included in the npm package, which are not required for the library to run. I have added a "files" section in package.json which includes only the files/folders required for the library.