### PR TITLE
Assure `host` is always an IP address

### DIFF
--- a/android/src/main/java/com/tradle/react/UdpReceiverTask.java
+++ b/android/src/main/java/com/tradle/react/UdpReceiverTask.java
@@ -47,7 +47,7 @@ public class UdpReceiverTask extends AsyncTask<Pair<DatagramSocket, UdpReceiverT
                 final InetAddress address = packet.getAddress();
                 final String base64Data = Base64.encodeToString(packet.getData(), packet.getOffset(),
                     packet.getLength(), Base64.NO_WRAP);
-                receiverListener.didReceiveData(base64Data, address.getHostName(), packet.getPort());
+                receiverListener.didReceiveData(base64Data, address.getHostAddress(), packet.getPort());
             } catch (IOException ioe) {
                 if (receiverListener != null) {
                     receiverListener.didReceiveError(ioe.getMessage());


### PR DESCRIPTION
Use `InetAddress.getHostAddress()` instead of `InetAddress.getHostName()` to get the host IP. The second one sometimes returns a textual name of the local host and this info is not really useful as a source address unless there's a way to resolve that name.