### PR TITLE
Issue-63: Update hostname regex to allow modern hostnames

### DIFF
--- a/UdpSocket.js
+++ b/UdpSocket.js
@@ -23,7 +23,7 @@ var Sockets = NativeModules.UdpSockets
 var base64 = require('base64-js')
 var ipRegex = require('ip-regex')
 // RFC 952 hostname format
-var hostnameRegex = /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+var hostnameRegex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 var noop = function () {}
 var instances = 0
 var STATE = {


### PR DESCRIPTION
The current regex for hostnames does not allow names like 0.pool.ntp.org.  0-9 is now allowed as the first character of hostnames.   An updated regex from https://www.regextester.com/23 adds 0-9 in appropriate places.