### PR TITLE
Allow callback to be passed as the only prop to bind

### DIFF
--- a/UdpSocket.js
+++ b/UdpSocket.js
@@ -22,6 +22,7 @@ var {
 var Sockets = NativeModules.UdpSockets
 var base64 = require('base64-js')
 var ipRegex = require('ip-regex')
+var normalizeBindOptions = require('./normalizeBindOptions')
 // RFC 952 hostname format
 var hostnameRegex = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 var noop = function () {}
@@ -295,19 +296,4 @@ function normalizeError (err) {
 
     return err
   }
-}
-
-function normalizeBindOptions(...args) {
-  const options = typeof args[0] === 'object' ? args[0] : {}
-  if (typeof args[0] === 'number') {
-    options.port = args[0]
-  }
-  if (typeof args[1] === 'string') {
-    options.address = args[1]
-  }
-  if (typeof args[args.length - 1] === 'function') {
-    options.callback = args[args.length - 1]
-  }
-
-  return options
 }

--- a/UdpSocket.js
+++ b/UdpSocket.js
@@ -73,20 +73,12 @@ UdpSocket.prototype._debug = function() {
   }
 }
 
-UdpSocket.prototype.bind = function(port, address, callback) {
+UdpSocket.prototype.bind = function(...args) {
   var self = this
 
   if (this._state !== STATE.UNBOUND) throw new Error('Socket is already bound')
 
-  if (typeof address === 'function') {
-    callback = address
-    address = undefined
-  }
-
-  if (typeof port === 'function') {
-    callback = port
-    port = undefined
-  }
+  let { port, address, callback } = normalizeBindOptions(...args)
 
   if (!address) address = '0.0.0.0'
 
@@ -303,4 +295,19 @@ function normalizeError (err) {
 
     return err
   }
+}
+
+function normalizeBindOptions(...args) {
+  const options = typeof args[0] === 'object' ? args[0] : {}
+  if (typeof args[0] === 'number') {
+    options.port = args[0]
+  }
+  if (typeof args[1] === 'string') {
+    options.address = args[1]
+  }
+  if (typeof args[args.length - 1] === 'function') {
+    options.callback = args[args.length - 1]
+  }
+
+  return options
 }

--- a/UdpSocket.js
+++ b/UdpSocket.js
@@ -83,6 +83,11 @@ UdpSocket.prototype.bind = function(port, address, callback) {
     address = undefined
   }
 
+  if (typeof port === 'function') {
+    callback = port
+    port = undefined
+  }
+
   if (!address) address = '0.0.0.0'
 
   if (!port) port = 0

--- a/normalizeBindOptions.js
+++ b/normalizeBindOptions.js
@@ -1,0 +1,21 @@
+module.exports = function normalizeBindOptions(...args) {
+  const [arg1, arg2] = args
+  const lastArg = args[args.length - 1]
+  let options = {}
+
+  if (typeof arg1 === 'object') {
+    options = arg1
+  } else if (typeof arg1 === 'number') {
+    options.port = arg1
+  } else if (typeof arg1 === 'string') {
+    options.address = arg1
+  }
+  if (typeof arg2 === 'string') {
+    options.address = arg2
+  }
+  if (typeof lastArg === 'function') {
+    options.callback = lastArg
+  }
+
+  return options
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "node's dgram API for react-native",
   "main": "UdpSockets.js",
   "scripts": {
-    "start": "exit 1"
+    "start": "exit 1",
+    "test": "mocha"
   },
   "browser": {
     "dgram": "./UdpSockets.js"
@@ -38,5 +39,8 @@
     "inherits": "^2.0.1",
     "ip-regex": "^1.0.3",
     "util": "^0.10.3"
+  },
+  "devDependencies": {
+    "mocha": "^6.0.1"
   }
 }

--- a/test/normalizeBindOptions.test.js
+++ b/test/normalizeBindOptions.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert')
+const normalizeBindOptions = require('../normalizeBindOptions')
+const prettify = obj => JSON.stringify(obj, null, 2)
+
+describe('normalizeBindOptions', () => {
+  const args = [
+    { name: 'port', value: 1234 },
+    { name: 'address', value: '1.2.3.4' },
+    { name: 'callback', value: () => {} },
+  ]
+
+  it('should support all combinations of arguments', () => {
+    // check every combination of arguments (retaining order)
+    // use a bit mask to decide whether to keep an argument
+    for (let i = 0, numCombinations = Math.pow(2, args.length); i < numCombinations; i++) {
+      const usedArgs = args.filter((arg, bit) => (i + 1) & 1 << bit)
+      const expected = {}
+      usedArgs.forEach(arg => expected[arg.name] = arg.value)
+      const usedArgsValues = usedArgs.map(arg => arg.value)
+
+      const result = normalizeBindOptions(...usedArgsValues)
+      try {
+        assert.deepEqual(result, expected)
+      } catch (err) {
+        throw new Error(`for args: ${prettify(usedArgsValues)}\nexpected: ${prettify(expected)}\ngot ${prettify(result)}`)
+      }
+    }
+  })
+})


### PR DESCRIPTION
`bind` method should also be able to receive just one argument that is a callback function, as can be seen in [dgram source](https://github.com/nodejs/node/blob/master/lib/dgram.js#L198)

Some libraries rely on this behavior, such as [node-milight-promise](https://github.com/mwittig/node-milight-promise) 