### PR TITLE
Fix breaking change w/ Gradle dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
 dependencies {
     def supportLibVersion = project.hasProperty('supportLibVersion') ? project.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:$supportLibVersion"
-    compile 'com.facebook.react:react-native:+'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
## Intent
This fixes a breaking API change with the Android Gradle plugin, which was deprecated as of version 3.0.0 and later made obsolete. 

## Changes
When adding Gradle dependencies, the `compile` command has been removed and replaced with `implementation`/`api`.

## More information
- [Gradle support docs](https://docs.gradle.org/5.4.1/userguide/java_library_plugin.html#sec:java_library_separation)
- [Android deprecation doc](https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations)