### PR TITLE
Catch all possible exceptions while binding SocketClient

### DIFF
--- a/android/src/main/java/com/tradle/react/UdpSocketClient.java
+++ b/android/src/main/java/com/tradle/react/UdpSocketClient.java
@@ -80,12 +80,15 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
             socketAddress = new InetSocketAddress(port);
         }
 
-        mSocket.setReuseAddress(mReuseAddress);
-        mSocket.bind(socketAddress);
+        try {
+            mSocket.setReuseAddress(mReuseAddress);
+            mSocket.bind(socketAddress);
 
-        // begin listening for data in the background
-        mReceiverTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
-                new Pair<DatagramSocket, UdpReceiverTask.OnDataReceivedListener>(mSocket, this));
+            // begin listening for data in the background
+            mReceiverTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+                    new Pair<DatagramSocket, UdpReceiverTask.OnDataReceivedListener>(mSocket, this));
+        } catch (Exception e) {
+        }
     }
 
     /**


### PR DESCRIPTION
Addresses [issue](https://github.com/tradle/react-native-udp/issues/119).

Cannot say that this is the fix, because I was not able to reproduce the crash locally. But can assure that, with this patch we no longer see the same crash.