### PR TITLE
fix: Add missing attribute "homepage" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-native-udp",
   "version": "4.0.0",
   "description": "React Native UDP socket API for Android & iOS",
+  "homepage": "https://github.com/tradle/react-native-udp",
   "main": "src/index.js",
   "types": "lib/types/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Attribute "homepage" in package.json is required during pod install.