### PR TITLE
fix: Fix Xcode 12 compatibility

### DIFF
--- a/react-native-udp.podspec
+++ b/react-native-udp.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, "7.0"
   s.source         = { :git => package_json["repository"]["url"].gsub(/(http.*)/).first, :tag => "v#{s.version}" }
   s.source_files   = 'ios/**/*.{h,m}'
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'CocoaAsyncSocket'
 end


### PR DESCRIPTION
Summary
Xcode 12 won't build if a module depends on React instead of React-Core. 

Reference: facebook/react-native#29633 (comment)