### PR TITLE
feat: Add rx timestamp to rinfo payload

### DIFF
--- a/android/src/main/java/com/tradle/react/UdpSockets.java
+++ b/android/src/main/java/com/tradle/react/UdpSockets.java
@@ -297,6 +297,7 @@ public final class UdpSockets extends ReactContextBaseJavaModule
      */
     @Override
     public void didReceiveData(final UdpSocketClient socket, final String data, final String host, final int port) {
+        final long ts = System.currentTimeMillis();
         executorService.execute(new Thread(new Runnable() {
             @Override
             public void run() {
@@ -317,6 +318,8 @@ public final class UdpSockets extends ReactContextBaseJavaModule
                 eventParams.putString("data", data);
                 eventParams.putString("address", host);
                 eventParams.putInt("port", port);
+                // Use string for ts since it's 64 bits and putInt is only 32
+                eventParams.putString("ts", Long.toString(ts));
 
                 ReactContext reactContext = UdpSockets.this.getReactApplicationContext();
                 reactContext

--- a/ios/UdpSockets.m
+++ b/ios/UdpSockets.m
@@ -127,13 +127,15 @@ RCT_EXPORT_METHOD(dropMembership:(nonnull NSNumber*)cId
 
 - (void) onData:(UdpSocketClient*) client data:(NSData *)data host:(NSString *)host port:(uint16_t)port
 {
+    long ts = (long)([[NSDate date] timeIntervalSince1970] * 1000);
     NSNumber *clientID = [[_clients allKeysForObject:client] objectAtIndex:0];
     NSString *base64String = [data base64EncodedStringWithOptions:0];
     [self.bridge.eventDispatcher sendDeviceEventWithName:[NSString stringWithFormat:@"udp-%@-data", clientID]
                                                     body:@{
                                                            @"data": base64String,
                                                            @"address": host,
-                                                           @"port": [NSNumber numberWithInt:port]
+                                                           @"port": [NSNumber numberWithInt:port],
+                                                           @"ts": [[NSNumber numberWithLong: ts] stringValue]
                                                            }
      ];
 }

--- a/src/UdpSocket.js
+++ b/src/UdpSocket.js
@@ -160,7 +160,7 @@ export default class UdpSocket extends EventEmitter {
 
   /**
    * @private
-   * @param {{ data: string; address: string; port: number; }} info
+   * @param {{ data: string; address: string; port: number; ts: number; }} info
    */
   _onReceive(info) {
     // from base64 string
@@ -170,6 +170,7 @@ export default class UdpSocket extends EventEmitter {
       port: info.port,
       family: 'IPv4',
       size: buf.length,
+      ts: Number(info.ts),
     }
     this.emit('message', buf, rinfo)
   }


### PR DESCRIPTION
For doing time sync with UDP packets, the best available rx timestamp is needed to avoid delays introduced in callback event reporting.  This pull request captures the time at a low level and passes it in the rinfo callback object as a millisecond timestamp.  Verified on Android and iOS.