### PR TITLE
decreased the instance variable on socket close

### DIFF
--- a/src/UdpSocket.js
+++ b/src/UdpSocket.js
@@ -92,7 +92,7 @@ export default class UdpSocket extends EventEmitter {
        * @param {any} err
        * @param {{ address: any; port: any; }} addr
        */
-      function(err, addr) {
+      function (err, addr) {
         err = normalizeError(err)
         if (err) {
           // questionable: may want to self-destruct and
@@ -122,6 +122,7 @@ export default class UdpSocket extends EventEmitter {
     this.once('close', callback)
     this._debug('closing')
     this._subscription.remove()
+    instances--
     Sockets.close(
       this._id,
       /**


### PR DESCRIPTION
I noticed that the instance number keeps increasing even when I close my sockets. It's slightly annoying since I was not sure if my previously opened sockets were actually destroyed or not.