### PR TITLE
added a getter for the socket state

### DIFF
--- a/src/UdpSocket.js
+++ b/src/UdpSocket.js
@@ -122,6 +122,7 @@ export default class UdpSocket extends EventEmitter {
     this.once('close', callback)
     this._debug('closing')
     this._subscription.remove()
+    instances--
     Sockets.close(
       this._id,
       /**
@@ -277,6 +278,14 @@ export default class UdpSocket extends EventEmitter {
       port: this._port,
       family: 'IPv4',
     }
+  }
+
+  /**
+   * Returns the state of the socket
+   * @return {Number} -  0 (UNBOUND), 1 (BINDING), 2 (BOUND)
+   */
+  getState() {
+    return this._state
   }
 
   /**


### PR DESCRIPTION
So far if I want to be sure that the socket is bound and ready to use, I have assume an error will be thrown. I would prefer to be able to check this myself. After reading through the Javascript code, the only way to do it right now is to call the `address()` function and check for an error. At least this is more straightforward.