### PR TITLE
fix: Remove AsyncTask in the send function (it's deprecated)

### DIFF
--- a/android/src/main/java/com/tradle/react/UdpSocketClient.java
+++ b/android/src/main/java/com/tradle/react/UdpSocketClient.java
@@ -15,6 +15,9 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static com.tradle.react.UdpSenderTask.OnDataSentListener;
 
@@ -25,13 +28,15 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
     private final OnDataReceivedListener mReceiverListener;
     private final OnRuntimeExceptionListener mExceptionListener;
 
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
     private UdpReceiverTask mReceiverTask;
 
     private final Map<UdpSenderTask, Callback> mPendingSends;
     private DatagramSocket mSocket;
     private boolean mIsMulticastSocket = false;
 
-    public UdpSocketClient(OnDataReceivedListener receiverListener,  OnRuntimeExceptionListener exceptionListener) {
+    public UdpSocketClient(OnDataReceivedListener receiverListener, OnRuntimeExceptionListener exceptionListener) {
         this.mReceiverListener = receiverListener;
         this.mExceptionListener = exceptionListener;
         this.mPendingSends = new ConcurrentHashMap<>();
@@ -125,10 +130,7 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
 
         byte[] data = Base64.decode(base64String, Base64.NO_WRAP);
 
-        UdpSenderTask task = new UdpSenderTask(mSocket, this);
-        UdpSenderTask.SenderPacket packet = new UdpSenderTask.SenderPacket();
-        packet.data = data;
-        packet.socketAddress = new InetSocketAddress(InetAddress.getByName(address), port);
+        UdpSenderTask task = new UdpSenderTask(mSocket, this, new InetSocketAddress(InetAddress.getByName(address), port), data);
 
         if (callback != null) {
             synchronized (mPendingSends) {
@@ -136,7 +138,7 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
             }
         }
 
-        task.execute(packet);
+        executor.submit(task);
     }
 
     /**
@@ -156,6 +158,9 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
         if (mReceiverTask != null && mReceiverTask.isRunning()) {
             mReceiverTask.terminate();
         }
+
+        // stop pending send tasks
+        executor.shutdownNow();
 
         // close the socket
         if (mSocket != null && !mSocket.isClosed()) {

--- a/android/src/main/java/com/tradle/react/UdpSockets.java
+++ b/android/src/main/java/com/tradle/react/UdpSockets.java
@@ -66,7 +66,7 @@ public final class UdpSockets extends ReactContextBaseJavaModule
     }
 
     /**
-     * Private method to retrieve clients. Must be called from a GuardedAsyncTask for thread-safety.
+     * Private method to retrieve clients.
      */
     private UdpSocketClient findClient(final Integer cId, final Callback callback) {
         final UdpSocketClient client = mClients.get(cId);


### PR DESCRIPTION
We were seeing an issue in Sentry due to the use of AsyncTask in the send packet  function:

<img width="620" alt="screenshot-sentry-crash" src="https://user-images.githubusercontent.com/636528/148999881-00ec4ba4-8bee-46aa-8dcd-0351df165075.png">

It's  not occurring a lot, but enough to fix :-). The bug is hard to reproduce, we assume it's due to the Activity being paused, or the app relaunched. The AsyncTask is getting executed but the socket is no more.
Given that [https://developer.android.com/reference/android/os/AsyncTask](AsyncTask) is deprecated, I rewrote it.

_We are currently testing these change in production._