### PR TITLE
fix(Android): Catch all exceptions and redirect them to JS

### DIFF
--- a/android/src/main/java/com/tradle/react/UdpSockets.java
+++ b/android/src/main/java/com/tradle/react/UdpSockets.java
@@ -220,13 +220,8 @@ public final class UdpSockets extends ReactContextBaseJavaModule
 
                 try {
                     client.send(base64String, port, address, callback);
-                } catch (IllegalStateException ise) {
-                    callback.invoke(UdpErrorUtil.getError(null, ise.getMessage()));
-                } catch (UnknownHostException uhe) {
-                    callback.invoke(UdpErrorUtil.getError(null, uhe.getMessage()));
-                } catch (IOException ioe) {
-                    // an exception occurred
-                    callback.invoke(UdpErrorUtil.getError(null, ioe.getMessage()));
+                } catch (Exception exception) {
+                    callback.invoke((UdpErrorUtil.getError(null, exception.getMessage())));
                 }
             }
         }));


### PR DESCRIPTION
Due to my improvement: https://github.com/tradle/react-native-udp/pull/197, if you now try to send a packet to a closed channel, you get a `RejectedExecutionException` exception.

As you can see in the changed file, the send method only catches specific exceptions, and not this `RejectedExecutionException`. This actually causes an app to crash as this is unhandled.

But since this is a React Native library; it's better to catch all exceptions and pass them along to React Native. There, in your js/ts code, apps can try catch this and recover from this case.

How to reproduce?
1. open a socket
2. close a socket
3. try to send something over that closed socket