### PR TITLE
fix close socket

### DIFF
--- a/android/src/main/java/com/tradle/react/UdpReceiverTask.java
+++ b/android/src/main/java/com/tradle/react/UdpReceiverTask.java
@@ -50,7 +50,6 @@ public class UdpReceiverTask implements Runnable {
                 receiverListener.didReceiveData(base64Data, address.getHostAddress(), packet.getPort());
             } catch(java.net.SocketTimeoutException timeout) {                                              // receive timed-out, needed to get out of the loop when socket gets closed
                 continue;
-            }
             } catch (IOException ioe) {
                 if (receiverListener != null) {
                     receiverListener.didReceiveError(ioe.getMessage());

--- a/android/src/main/java/com/tradle/react/UdpReceiverTask.java
+++ b/android/src/main/java/com/tradle/react/UdpReceiverTask.java
@@ -48,6 +48,9 @@ public class UdpReceiverTask implements Runnable {
                 final String base64Data = Base64.encodeToString(packet.getData(), packet.getOffset(),
                         packet.getLength(), Base64.NO_WRAP);
                 receiverListener.didReceiveData(base64Data, address.getHostAddress(), packet.getPort());
+            } catch(java.net.SocketTimeoutException timeout) {                                              // receive timed-out, needed to get out of the loop when socket gets closed
+                continue;
+            }
             } catch (IOException ioe) {
                 if (receiverListener != null) {
                     receiverListener.didReceiveError(ioe.getMessage());

--- a/android/src/main/java/com/tradle/react/UdpSocketClient.java
+++ b/android/src/main/java/com/tradle/react/UdpSocketClient.java
@@ -75,7 +75,7 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
 
         mSocket = new MulticastSocket(socketAddress);
         mSocket.setReuseAddress(true);
-        msocket.setSoTimeout(500);
+        mSocket.setSoTimeout(500);
 
         // begin listening for data in the background
         mReceiverTask = new UdpReceiverTask(mSocket, this);

--- a/android/src/main/java/com/tradle/react/UdpSocketClient.java
+++ b/android/src/main/java/com/tradle/react/UdpSocketClient.java
@@ -75,6 +75,7 @@ public final class UdpSocketClient implements UdpReceiverTask.OnDataReceivedList
 
         mSocket = new MulticastSocket(socketAddress);
         mSocket.setReuseAddress(true);
+        msocket.setSoTimeout(500);
 
         // begin listening for data in the background
         mReceiverTask = new UdpReceiverTask(mSocket, this);


### PR DESCRIPTION
On some devices, the close method remained stuck: the UdpReceiverTask would never stop. This can be fixed by adding a timeout to the socket.